### PR TITLE
Use flags to upload code coverage.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,10 +1,17 @@
 # Codecov configuration for monorepo
 coverage:
-  # Overall coverage thresholds for the monorepo
   status:
     project:
       default:
         target: 80%
+        threshold: 5%
+      mobile-web:
+        flags: mobile-web
+        target: 85%
+        threshold: 5%
+      monorepo:
+        flags: monorepo
+        target: 82%
         threshold: 5%
     patch:
       default:
@@ -34,33 +41,6 @@ ignore:
   - "**/*.d.ts"
   - "**/src/scripts/*.ts"
 
-# Flag-specific configurations
-flags:
-  # Individual package flags
-  mobile-web:
-    target: 85%
-    threshold: 5%
-    # paths: specifies which directories/files to include in coverage for this flag
-    # Only coverage reports from files in packages/mobile-web/ will be counted for mobile-web flag
-    paths:
-      - "packages/mobile-web/"
-  # Add more subpackages like the example below in the future
-  # backend-api:
-  #   target: 80%
-  #   threshold: 5%
-  #   paths:
-  #     - "packages/backend-api/"
-  # shared-utils:
-  #   target: 90%
-  #   threshold: 5%
-  #   paths:
-  #     - "packages/shared-utils/"
-  
-  # Monorepo combined flag
-  monorepo:
-    target: 82%
-    threshold: 5%
-
 # File-specific configurations
 parsers:
   gcov:
@@ -68,4 +48,4 @@ parsers:
       conditional: yes
       loop: yes
       method: no
-      macro: no 
+      macro: no

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -40,12 +40,21 @@ flags:
   mobile-web:
     target: 85%
     threshold: 5%
-  backend-api:
-    target: 80%
-    threshold: 5%
-  shared-utils:
-    target: 90%
-    threshold: 5%
+    # paths: specifies which directories/files to include in coverage for this flag
+    # Only coverage reports from files in packages/mobile-web/ will be counted for mobile-web flag
+    paths:
+      - "packages/mobile-web/"
+  # Add more subpackages like the example below in the future
+  # backend-api:
+  #   target: 80%
+  #   threshold: 5%
+  #   paths:
+  #     - "packages/backend-api/"
+  # shared-utils:
+  #   target: 90%
+  #   threshold: 5%
+  #   paths:
+  #     - "packages/shared-utils/"
   
   # Monorepo combined flag
   monorepo:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -27,7 +27,7 @@ jobs:
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
             files: packages/mobile-web/coverage/*.json
-            flags: mobile-web-${{ runner.os }}-node${{ matrix.node }}
+            flags: mobile-web
             name: mobile-web-coverage
             
       # Add more packages as you create them
@@ -53,5 +53,5 @@ jobs:
         with:
             token: ${{ secrets.CODECOV_TOKEN }}
             files: packages/*/coverage/*.json
-            flags: monorepo-${{ runner.os }}-node${{ matrix.node }}
+            flags: monorepo
             name: monorepo-combined-coverage

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A collection of Model Context Protocol (MCP) tools for Salesforce Mobile Web applications. These tools provide expert grounding for implementing various mobile capabilities in Salesforce Lightning Web Components (LWC).
 
-[![Codecov](https://codecov.io/gh/forcedotcom/mobile-mcp-tools/branch/main/graph/badge.svg?flag=monorepo)](https://codecov.io/gh/forcedotcom/mobile-mcp-tools?flag=monorepo)
-[![mobile-web coverage](https://codecov.io/gh/forcedotcom/mobile-mcp-tools/branch/main/graph/badge.svg?flag=mobile-web)](https://codecov.io/gh/forcedotcom/mobile-mcp-tools?flag=mobile-web)
+[![Codecov](https://codecov.io/gh/forcedotcom/mobile-mcp-tools/graph/badge.svg?flag=monorepo)](https://codecov.io/gh/forcedotcom/mobile-mcp-tools?flag=monorepo)
+[![mobile-web coverage](https://codecov.io/gh/forcedotcom/mobile-mcp-tools/graph/badge.svg?flag=mobile-web)](https://codecov.io/gh/forcedotcom/mobile-mcp-tools?flag=mobile-web)
 [![Build Status](https://github.com/forcedotcom/mobile-mcp-tools/workflows/run-tests/badge.svg)](https://github.com/forcedotcom/mobile-mcp-tools/actions)
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 A collection of Model Context Protocol (MCP) tools for Salesforce Mobile Web applications. These tools provide expert grounding for implementing various mobile capabilities in Salesforce Lightning Web Components (LWC).
 
-[![Codecov](https://codecov.io/gh/forcedotcom/mobile-mcp-tools/graph/badge.svg?flag=monorepo)](https://codecov.io/gh/forcedotcom/mobile-mcp-tools?flag=monorepo)
-[![mobile-web coverage](https://codecov.io/gh/forcedotcom/mobile-mcp-tools/graph/badge.svg?flag=mobile-web)](https://codecov.io/gh/forcedotcom/mobile-mcp-tools?flag=mobile-web)
+[![Codecov](https://codecov.io/gh/forcedotcom/mobile-mcp-tools/branch/main/graph/badge.svg?flag=monorepo)](https://codecov.io/gh/forcedotcom/mobile-mcp-tools?flag=monorepo)
+[![mobile-web coverage](https://codecov.io/gh/forcedotcom/mobile-mcp-tools/branch/main/graph/badge.svg?flag=mobile-web)](https://codecov.io/gh/forcedotcom/mobile-mcp-tools?flag=mobile-web)
 [![Build Status](https://github.com/forcedotcom/mobile-mcp-tools/workflows/run-tests/badge.svg)](https://github.com/forcedotcom/mobile-mcp-tools/actions)
 
 ## Features


### PR DESCRIPTION
### What does this PR do?
Codecov requires correct flags to be passed in the yaml for uploading code coverage data in order to distinguish the coverage report, and, for them to be linked to the badges on readme.

