### PR TITLE
Some project configuration cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1581,10 +1581,6 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "license": "MIT"
     },
-    "node_modules/@mobile-mcp-tools/project-maintenance-utilities": {
-      "resolved": "packages/project-maintenance-utilities",
-      "link": true
-    },
     "node_modules/@modelcontextprotocol/inspector": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector/-/inspector-0.16.1.tgz",
@@ -3521,6 +3517,10 @@
     },
     "node_modules/@salesforce/mobile-web-mcp-server": {
       "resolved": "packages/mobile-web",
+      "link": true
+    },
+    "node_modules/@salesforce/project-maintenance-utilities": {
+      "resolved": "packages/project-maintenance-utilities",
       "link": true
     },
     "node_modules/@sinclair/typebox": {
@@ -10140,7 +10140,7 @@
       }
     },
     "packages/project-maintenance-utilities": {
-      "name": "@mobile-mcp-tools/project-maintenance-utilities",
+      "name": "@salesforce/project-maintenance-utilities",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/packages/evaluation/package.json
+++ b/packages/evaluation/package.json
@@ -2,6 +2,7 @@
   "name": "@salesforce/mobile-mcp-tools-evaluation",
   "version": "0.0.1",
   "type": "module",
+  "private": true,
   "files": [
     "dist"
   ],

--- a/packages/mobile-web/package.json
+++ b/packages/mobile-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/mobile-web-mcp-server",
-  "version": "0.0.1",
+  "version": "0.0.1-alpha.1",
   "type": "module",
   "files": [
     "dist",

--- a/packages/project-maintenance-utilities/package.json
+++ b/packages/project-maintenance-utilities/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mobile-mcp-tools/project-maintenance-utilities",
+  "name": "@salesforce/project-maintenance-utilities",
   "version": "1.0.0",
   "private": true,
   "type": "module",

--- a/packages/project-maintenance-utilities/project.json
+++ b/packages/project-maintenance-utilities/project.json
@@ -1,5 +1,5 @@
 {
-  "name": "@mobile-mcp-tools/project-maintenance-utilities",
+  "name": "@salesforce/project-maintenance-utilities",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "packages/project-maintenance-utilities/src",
   "projectType": "library",


### PR DESCRIPTION
### What does this PR do?

- Makes the evaluation package private, as it's not meant to be published.
- Changes the namespace/scope of the `project-maintenance-utilities` package to `@salesforce/`, to avoid any dependency confusion considerations. This package is already private, as it too is not meant to be published.