### PR TITLE
Updating spec to require title annotation

### DIFF
--- a/docs/2_salesforce-mobile-web-mcp-server.md
+++ b/docs/2_salesforce-mobile-web-mcp-server.md
@@ -111,7 +111,7 @@ This ensures a frictionless, installation-free experience for developers and too
 
 _See [Tool Annotations](https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations) in the Model Context Protocol User Guide_
 
-The following server tool annotations are applied based on tool type:
+All tools include a `title` annotation using the human-readable title specified in their respective tool suite documentation. The following additional server tool annotations are applied based on tool type:
 
 **Information-Only Tools (e.g., Native Capabilities):**
 

--- a/docs/3_mobile_native_capabilities.md
+++ b/docs/3_mobile_native_capabilities.md
@@ -24,6 +24,8 @@ The Mobile Native Capabilities tool suite provides grounding context for creatin
 
 # MCP Server Tools
 
+Each tool's **Title** field is used as the `title` annotation in the MCP server implementation, providing human-readable display names for client interfaces.
+
 ## App Review
 
 **Name:** `sfmobile-web-app-review`  

--- a/docs/4_mobile_offline.md
+++ b/docs/4_mobile_offline.md
@@ -327,6 +327,8 @@ The MCP server package includes:
 
 # MCP Server Tools
 
+Each tool's **Title** field is used as the `title` annotation in the MCP server implementation, providing human-readable display names for client interfaces.
+
 ## Tool 1: Mobile Offline Guidance
 
 **Name:** `sfmobile-web-offline-guidance`  

--- a/package-lock.json
+++ b/package-lock.json
@@ -10117,7 +10117,7 @@
     },
     "packages/mobile-web": {
       "name": "@salesforce/mobile-web-mcp-server",
-      "version": "0.0.1",
+      "version": "0.0.1-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.13.2",

--- a/packages/mobile-web/src/tools/mobile-offline/offline-analysis/tool.ts
+++ b/packages/mobile-web/src/tools/mobile-offline/offline-analysis/tool.ts
@@ -34,6 +34,7 @@ const LINTER_CONFIG: Linter.Config = {
 
 export class OfflineAnalysisTool implements Tool {
   readonly name = 'Mobile Web Offline Analysis Tool';
+  readonly title = 'Salesforce Mobile Offline LWC Expert Static Analysis';
   readonly description =
     'Analyzes LWC components for mobile-specific issues and provides detailed recommendations for improvements. It can be leveraged to check if components are mobile-ready.';
   readonly toolId = 'sfmobile-web-offline-analysis';
@@ -55,7 +56,10 @@ export class OfflineAnalysisTool implements Tool {
         description: this.description,
         inputSchema: this.inputSchema.shape,
         outputSchema: this.outputSchema.shape,
-        annotations: annotations,
+        annotations: {
+          ...annotations,
+          title: this.title,
+        },
       },
       async (code: LwcCodeType) => {
         try {

--- a/packages/mobile-web/src/tools/mobile-offline/offline-guidance/tool.ts
+++ b/packages/mobile-web/src/tools/mobile-offline/offline-guidance/tool.ts
@@ -21,6 +21,7 @@ const EMPTY_INPUT_SCHEMA = z.object({}).describe('No input required');
 
 export class OfflineGuidanceTool implements Tool {
   readonly name = 'Mobile Web Offline Guidance Tool';
+  readonly title = 'Salesforce Mobile Offline LWC Expert Instruction Delivery';
   readonly description =
     'Provides structured review instructions to detect and remediate Mobile Offline code violations in Lightning web components (LWCs) for Salesforce Mobile Apps.';
   readonly toolId = 'sfmobile-web-offline-guidance';
@@ -34,7 +35,10 @@ export class OfflineGuidanceTool implements Tool {
         description: this.description,
         inputSchema: this.inputSchema.shape,
         outputSchema: this.outputSchema.shape,
-        annotations: annotations,
+        annotations: {
+          ...annotations,
+          title: this.title,
+        },
       },
       async () => {
         try {

--- a/packages/mobile-web/src/tools/native-capabilities/appReview/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/appReview/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class AppReviewTool extends BaseTool {
   readonly name = 'App Review Service';
+  readonly title = 'Salesforce Mobile App Review LWC Native Capability';
   public readonly toolId = 'sfmobile-web-app-review';
   public readonly description =
     'Provides expert grounding to implement a mobile app store review feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/arSpaceCapture/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/arSpaceCapture/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class ArSpaceCaptureTool extends BaseTool {
   readonly name = 'AR Space Capture';
+  readonly title = 'Salesforce Mobile AR Space Capture LWC Native Capability';
   public readonly toolId = 'sfmobile-web-ar-space-capture';
   public readonly description =
     'Provides expert grounding to implement an AR Space Capture feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/barcodeScanner/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/barcodeScanner/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class BarcodeScannerTool extends BaseTool {
   readonly name = 'Barcode Scanner';
+  readonly title = 'Salesforce Mobile Barcode Scanner LWC Native Capability';
   public readonly toolId = 'sfmobile-web-barcode-scanner';
   public readonly description =
     'Provides expert grounding to implement a Barcode Scanner feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/baseTool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/baseTool.ts
@@ -16,6 +16,7 @@ import { Tool } from '../tool.js';
 export abstract class BaseTool implements Tool {
   public abstract readonly name: string;
   public abstract readonly description: string;
+  public abstract readonly title: string;
   protected abstract readonly typeDefinitionPath: string;
   public abstract readonly toolId: string;
   protected abstract readonly serviceDescription: string;
@@ -101,11 +102,17 @@ ${typeDefinitions}
   }
 
   public register(server: McpServer, annotations: ToolAnnotations): void {
+    // Add title annotation from the tool
+    const enhancedAnnotations = {
+      ...annotations,
+      title: this.title,
+    };
+
     server.tool(
       this.toolId,
       this.description,
       EmptySchema.shape,
-      annotations,
+      enhancedAnnotations,
       this.handleRequest.bind(this)
     );
   }

--- a/packages/mobile-web/src/tools/native-capabilities/biometrics/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/biometrics/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class BiometricsTool extends BaseTool {
   readonly name = 'Biometrics Service';
+  readonly title = 'Salesforce Mobile Biometrics Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-biometrics';
   public readonly description =
     'Provides expert grounding to implement a Biometrics feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/calendar/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/calendar/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class CalendarTool extends BaseTool {
   readonly name = 'Calendar Service';
+  readonly title = 'Salesforce Mobile Calendar Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-calendar';
   public readonly description =
     'Provides expert grounding to implement a Calendar feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/contacts/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/contacts/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class ContactsTool extends BaseTool {
   readonly name = 'Contacts Service';
+  readonly title = 'Salesforce Mobile Contacts Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-contacts';
   public readonly description =
     'Provides expert grounding to implement a Contacts feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/documentScanner/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/documentScanner/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class DocumentScannerTool extends BaseTool {
   readonly name = 'Document Scanner';
+  readonly title = 'Salesforce Mobile Document Scanner LWC Native Capability';
   public readonly toolId = 'sfmobile-web-document-scanner';
   public readonly description =
     'Provides expert grounding to implement a Document Scanner feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/geofencing/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/geofencing/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class GeofencingTool extends BaseTool {
   readonly name = 'Geofencing Service';
+  readonly title = 'Salesforce Mobile Geofencing Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-geofencing';
   public readonly description =
     'Provides expert grounding to implement a Geofencing feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/location/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/location/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class LocationTool extends BaseTool {
   readonly name = 'Location Service';
+  readonly title = 'Salesforce Mobile Location Services LWC Native Capability';
   public readonly toolId = 'sfmobile-web-location';
   public readonly description =
     'Provides expert grounding to implement a Location feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/nfc/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/nfc/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class NfcTool extends BaseTool {
   readonly name = 'NFC Service';
+  readonly title = 'Salesforce Mobile NFC Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-nfc';
   public readonly description =
     'Provides expert grounding to implement an NFC feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/native-capabilities/payments/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/payments/tool.ts
@@ -9,6 +9,7 @@ import { BaseTool } from '../baseTool.js';
 
 export class PaymentsTool extends BaseTool {
   readonly name = 'Payments Service';
+  readonly title = 'Salesforce Mobile Payments Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-payments';
   public readonly description =
     'Provides expert grounding to implement a Payments feature in a Salesforce Lightning web component (LWC).';

--- a/packages/mobile-web/src/tools/tool.ts
+++ b/packages/mobile-web/src/tools/tool.ts
@@ -14,6 +14,8 @@ export interface Tool {
   readonly name: string;
   /** A description of what the tool does */
   readonly description: string;
+  /** Human-readable title for display in client interfaces */
+  readonly title: string;
   /** Unique identifier for the tool */
   readonly toolId: string;
   /** Schema defining the input parameters for the tool */

--- a/packages/mobile-web/tests/tools/mobile-offline/offline-analysis/tool.test.ts
+++ b/packages/mobile-web/tests/tools/mobile-offline/offline-analysis/tool.test.ts
@@ -44,7 +44,7 @@ describe('OfflineAnalysisTool', () => {
           description: tool.description,
           inputSchema: tool.inputSchema.shape,
           outputSchema: tool.outputSchema.shape,
-          annotations: defaultTestAnnotations,
+          annotations: { ...defaultTestAnnotations, title: tool.title },
         }),
         expect.any(Function)
       );

--- a/packages/mobile-web/tests/tools/mobile-offline/offline-guidance/tool.test.ts
+++ b/packages/mobile-web/tests/tools/mobile-offline/offline-guidance/tool.test.ts
@@ -52,7 +52,7 @@ describe('OfflineGuidanceTool', () => {
           description: tool.description,
           inputSchema: tool.inputSchema.shape,
           outputSchema: tool.outputSchema.shape,
-          annotations: defaultTestAnnotations,
+          annotations: { ...defaultTestAnnotations, title: tool.title },
         }),
         expect.any(Function)
       );


### PR DESCRIPTION
### What does this PR do?

Makes the linkage between MCP server tool titles and the `title` annotation of the tool, in the spec.