### PR TITLE
fix: update the example code in the komaci rule

### DIFF
--- a/packages/mobile-web/src/tools/mobile-offline/offline-analysis/ruleConfig.ts
+++ b/packages/mobile-web/src/tools/mobile-offline/offline-analysis/ruleConfig.ts
@@ -45,7 +45,7 @@ const noWireConfigReferenceNonLocalPropertyRule: CodeAnalysisBaseIssueType = {
         - Update the wire configuration to use the getter name as the reactive parameter
         Example:
             // Instead of:
-            @wire(getData, { param: importedValue })
+            @wire(getData, { param: '$importedValue' })
             
             // Use:
             get localValue() {


### PR DESCRIPTION
Update Rule Example for Wire Configuration

- Summary:

This update modifies the rule configuration for wire decorators to ensure that reactive parameters are correctly referenced using getter names. This change enhances the code analysis by providing a more accurate example of how to use wire decorators with imported values.

- Changes:

File Modified: ruleConfig.ts
Key Update: Changed the example for wire configuration to use $importedValue instead of importedValue as the reactive parameter.

- Example:

Before:
Apply to barcodeScann...
)
After:
Apply to barcodeScann...
)

- Impact:

This change ensures that developers use the correct syntax for reactive parameters in wire decorators, which is crucial for maintaining proper reactivity in Lightning Web Components.

