### PR TITLE
update tool descriptions.

### DIFF
--- a/packages/mobile-web/src/tools/native-capabilities/appReview/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/appReview/tool.ts
@@ -12,7 +12,7 @@ export class AppReviewTool extends BaseTool {
   readonly title = 'Salesforce Mobile App Review LWC Native Capability';
   public readonly toolId = 'sfmobile-web-app-review';
   public readonly description =
-    'Provides expert grounding to implement a mobile app store review feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC App Review Service, laying the foundation for understanding mobile app review and offering expert-level guidance for implementing the App Review feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'appReview/appReviewService.d.ts';
   public readonly serviceName = 'App Review';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages app review facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the app review API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/arSpaceCapture/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/arSpaceCapture/tool.ts
@@ -12,7 +12,7 @@ export class ArSpaceCaptureTool extends BaseTool {
   readonly title = 'Salesforce Mobile AR Space Capture LWC Native Capability';
   public readonly toolId = 'sfmobile-web-ar-space-capture';
   public readonly description =
-    'Provides expert grounding to implement an AR Space Capture feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC AR Space Capture, laying the foundation for understanding mobile AR space capture and offering expert-level guidance for implementing the AR Space Capture feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'arSpaceCapture/arSpaceCapture.d.ts';
   public readonly serviceName = 'AR Space Capture';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages AR Space Capture facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the AR Space Capture API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/barcodeScanner/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/barcodeScanner/tool.ts
@@ -12,7 +12,7 @@ export class BarcodeScannerTool extends BaseTool {
   readonly title = 'Salesforce Mobile Barcode Scanner LWC Native Capability';
   public readonly toolId = 'sfmobile-web-barcode-scanner';
   public readonly description =
-    'Provides expert grounding to implement a Barcode Scanner feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC Barcode Scanner, laying the foundation for understanding mobile barcode scanner and offering expert-level guidance for implementing the Barcode Scanner feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'barcodeScanner/barcodeScanner.d.ts';
   public readonly serviceName = 'Barcode Scanner';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages barcode scanning facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the barcode scanning API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/biometrics/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/biometrics/tool.ts
@@ -12,7 +12,7 @@ export class BiometricsTool extends BaseTool {
   readonly title = 'Salesforce Mobile Biometrics Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-biometrics';
   public readonly description =
-    'Provides expert grounding to implement a Biometrics feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC Biometrics Service, laying the foundation for understanding mobile biometrics and offering expert-level guidance for implementing the Biometrics feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'biometrics/biometricsService.d.ts';
   public readonly serviceName = 'Biometrics';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages biometrics scanning facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the face recognition and the finger printing scanner of the mobile device to authorize the user, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/calendar/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/calendar/tool.ts
@@ -12,7 +12,7 @@ export class CalendarTool extends BaseTool {
   readonly title = 'Salesforce Mobile Calendar Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-calendar';
   public readonly description =
-    'Provides expert grounding to implement a Calendar feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC Calendar Service, laying the foundation for understanding mobile calendar and offering expert-level guidance for implementing the Calendar feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'calendar/calendarService.d.ts';
   public readonly serviceName = 'Calendar';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages calendar facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the calendar API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/contacts/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/contacts/tool.ts
@@ -12,7 +12,7 @@ export class ContactsTool extends BaseTool {
   readonly title = 'Salesforce Mobile Contacts Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-contacts';
   public readonly description =
-    'Provides expert grounding to implement a Contacts feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC Contacts Service, laying the foundation for understanding mobile contacts and offering expert-level guidance for implementing the Contacts feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'contacts/contactsService.d.ts';
   public readonly serviceName = 'Contacts';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages contacts facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the contacts API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/documentScanner/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/documentScanner/tool.ts
@@ -12,7 +12,7 @@ export class DocumentScannerTool extends BaseTool {
   readonly title = 'Salesforce Mobile Document Scanner LWC Native Capability';
   public readonly toolId = 'sfmobile-web-document-scanner';
   public readonly description =
-    'Provides expert grounding to implement a Document Scanner feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC Document Scanner, laying the foundation for understanding mobile document scanner and offering expert-level guidance for implementing the Document Scanner feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'documentScanner/documentScanner.d.ts';
   public readonly serviceName = 'Document Scanner';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages document scanning facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the document scanner API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/geofencing/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/geofencing/tool.ts
@@ -12,7 +12,7 @@ export class GeofencingTool extends BaseTool {
   readonly title = 'Salesforce Mobile Geofencing Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-geofencing';
   public readonly description =
-    'Provides expert grounding to implement a Geofencing feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC Geofencing Service, laying the foundation for understanding mobile geofencing and offering expert-level guidance for implementing the Geofencing feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'geofencing/geofencingService.d.ts';
   public readonly serviceName = 'Geofencing';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages geofencing facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the geofencing API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/location/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/location/tool.ts
@@ -12,7 +12,7 @@ export class LocationTool extends BaseTool {
   readonly title = 'Salesforce Mobile Location Services LWC Native Capability';
   public readonly toolId = 'sfmobile-web-location';
   public readonly description =
-    'Provides expert grounding to implement a Location feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC Location Service, laying the foundation for understanding mobile location and offering expert-level guidance for implementing the Location feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'location/locationService.d.ts';
   public readonly serviceName = 'Location';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages location facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the location API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/nfc/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/nfc/tool.ts
@@ -12,7 +12,7 @@ export class NfcTool extends BaseTool {
   readonly title = 'Salesforce Mobile NFC Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-nfc';
   public readonly description =
-    'Provides expert grounding to implement an NFC feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC NFC Service, laying the foundation for understanding mobile NFC and offering expert-level guidance for implementing the NFC feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'nfc/nfcService.d.ts';
   public readonly serviceName = 'NFC';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages NFC facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the NFC API of the mobile device, within the LWC.`;

--- a/packages/mobile-web/src/tools/native-capabilities/payments/tool.ts
+++ b/packages/mobile-web/src/tools/native-capabilities/payments/tool.ts
@@ -12,7 +12,7 @@ export class PaymentsTool extends BaseTool {
   readonly title = 'Salesforce Mobile Payments Service LWC Native Capability';
   public readonly toolId = 'sfmobile-web-payments';
   public readonly description =
-    'Provides expert grounding to implement a Payments feature in a Salesforce Lightning web component (LWC).';
+    'The MCP tool provides a comprehensive TypeScript-based API documentation for Salesforce LWC Payments Service, laying the foundation for understanding mobile payments and offering expert-level guidance for implementing the Payments feature in a Lightning Web Component (LWC).';
   protected readonly typeDefinitionPath = 'payments/paymentsService.d.ts';
   public readonly serviceName = 'Payments';
   protected readonly serviceDescription = `The following content provides grounding information for generating a Salesforce LWC that leverages payments facilities on mobile devices. Specifically, this context will cover the API types and methods available to leverage the payments API of the mobile device, within the LWC.`;


### PR DESCRIPTION
### What does this PR do?
Updated the tool description  so that when a prompt such as 
```
Explain the structure and contents of the API interface returned by const barcodes = await scanner.scan();, including what data is provided for each scanned barcode in SFScanner.js
```
then the MCP tool is triggered to provide the correct response.
