### PR TITLE
feat: add utils-xcode-add-files tool for adding source files to Xcode projects

### DIFF
--- a/docs/7_utils_xcode_add_files_design.md
+++ b/docs/7_utils_xcode_add_files_design.md
@@ -1,0 +1,190 @@
+# Utils Xcode Add Files - MCP Tool Design
+
+## Overview
+
+The `utils-xcode-add-files` MCP tool generates Ruby commands using the xcodeproj gem to add newly created files to Xcode projects. This tool addresses a common oversight where LLMs generate new Swift/Objective-C files but forget to add them to the Xcode project, resulting in compilation errors and missing functionality.
+
+**Core Philosophy**: Generate reliable xcodeproj gem commands that LLMs can execute to integrate new source files, providing transparency and control over the Xcode project modification process.
+
+---
+
+## Tool Specification
+
+### Input Schema
+
+```typescript
+{
+  projectPath: string;           // Absolute path to the Xcode project directory
+  xcodeProjectPath: string;      // Path to the .xcodeproj file (e.g., "MyApp.xcodeproj")
+  newFilePaths: string[];        // Array of newly created file paths relative to project root
+  targetName?: string;           // Optional: specific target to add files to (defaults to main app target)
+}
+```
+
+### Output Structure
+
+The tool returns a JSON response containing:
+- Success/failure status
+- Generated Ruby command using xcodeproj gem
+- Project path and file paths to be added
+- Target name (if specified)
+- Descriptive message
+
+## Implementation Approach
+
+The tool generates xcodeproj gem commands:
+
+1. **Validate Input**: Confirm project and files exist
+2. **Build Ruby Command**: Generate inline Ruby code using xcodeproj gem
+3. **Return Command**: Provide ready-to-execute command for LLM
+4. **LLM Execution**: LLM can review and execute the generated command
+5. **Transparent Control**: Full visibility into project modification process
+
+---
+
+## Example Output
+
+```json
+{
+  "success": true,
+  "command": "ruby -e \"require 'xcodeproj'; require 'json'; require 'pathname'; ...\"",
+  "projectPath": "/path/to/ContactApp.xcodeproj",
+  "filePaths": [
+    "/path/to/ContactManager.swift",
+    "/path/to/ContactView.swift"
+  ],
+  "targetName": "ContactApp",
+  "message": "Generated command to add 2 files to Xcode project"
+}
+```
+
+## Tool Implementation
+
+### Generated Ruby Command Structure
+
+The tool creates an inline Ruby command that:
+
+1. **Validates Project**: Confirms the .xcodeproj file exists
+2. **Opens Project**: Uses `Xcodeproj::Project.open()` to load the project
+3. **Finds Target**: Locates the specified target or uses the first available target
+4. **Processes Files**: For each file:
+   - Calculates relative path from project directory
+   - Creates file reference using `project.main_group.new_file()`
+   - Adds to build phase if it's a source file (.swift, .m, .mm, .c, .cpp, .cc, .cxx)
+5. **Saves Project**: Calls `project.save` to persist changes
+6. **Returns Results**: Outputs JSON with success status and file details
+
+### Example Generated Command
+
+```ruby
+ruby -e "
+require 'xcodeproj'
+require 'json'
+require 'pathname'
+
+begin
+  project_path = '/path/to/MyApp.xcodeproj'
+  target_name = nil
+  files_to_add = ['/path/to/ContactManager.swift', '/path/to/ContactView.swift']
+
+  unless File.exist?(project_path)
+    puts JSON.generate({
+      success: false,
+      error: 'Project file not found',
+      message: \"Could not find Xcode project at #{project_path}\"
+    })
+    exit 1
+  end
+
+  project = Xcodeproj::Project.open(project_path)
+  target = target_name ? project.targets.find { |t| t.name == target_name } : project.targets.first
+
+  unless target
+    puts JSON.generate({
+      success: false,
+      error: 'Target not found',
+      message: 'No targets found in project'
+    })
+    exit 1
+  end
+
+  files_added = []
+  files_failed = []
+
+  files_to_add.each do |file_path|
+    unless File.exist?(file_path)
+      files_failed << file_path
+      next
+    end
+
+    begin
+      project_dir = File.dirname(project_path)
+      relative_path = Pathname.new(file_path).relative_path_from(Pathname.new(project_dir)).to_s
+      file_ref = project.main_group.new_file(relative_path)
+      
+      file_ext = File.extname(file_path).downcase
+      source_extensions = ['.swift', '.m', '.mm', '.c', '.cpp', '.cc', '.cxx']
+      
+      if source_extensions.include?(file_ext)
+        target.source_build_phase.add_file_reference(file_ref)
+      end
+      
+      files_added << File.basename(file_path)
+    rescue => e
+      files_failed << \"#{file_path}: #{e.message}\"
+    end
+  end
+
+  project.save
+
+  result = {
+    success: true,
+    filesAdded: files_added,
+    target: target.name,
+    buildStatus: 'completed',
+    message: \"Successfully added #{files_added.length} files to Xcode project\"
+  }
+  
+  if files_failed.any?
+    result[:warnings] = \"Failed to add #{files_failed.length} files: #{files_failed.join(', ')}\"
+  end
+
+  puts JSON.generate(result)
+
+rescue => e
+  puts JSON.generate({
+    success: false,
+    error: e.class.name,
+    message: e.message
+  })
+  exit 1
+end
+"
+```
+
+## Error Handling
+
+The generated Ruby command handles common failure scenarios:
+
+- **Project file not found**: Returns error if .xcodeproj doesn't exist
+- **Invalid file paths**: Skips non-existent files and reports them in warnings
+- **Target not found**: Returns error if specified target doesn't exist
+- **File addition failures**: Catches exceptions and reports failed files
+- **Automatic project saving**: Uses xcodeproj gem's built-in save functionality
+
+## Advantages of xcodeproj Gem Approach
+
+- **Reliability**: Uses the same gem that CocoaPods uses for project manipulation
+- **Safety**: Built-in validation and error handling
+- **Maintainability**: No manual pbxproj file parsing or UUID generation
+- **Transparency**: LLM can review the generated command before execution
+- **Flexibility**: Easy to modify or extend the generated Ruby code
+
+## Important Notes
+
+- **Command generation**: Tool generates Ruby commands instead of executing them directly
+- **LLM control**: LLM can review and execute commands at their discretion
+- **xcodeproj gem dependency**: Leverages CocoaPods prerequisite for iOS Mobile SDK apps
+- **Automatic project saving**: Generated command saves project after modifications
+- **File type detection**: Automatic detection of source files for build phase inclusion
+- **Error reporting**: Comprehensive error handling with JSON output

--- a/packages/mobile-native-mcp-server/src/index.ts
+++ b/packages/mobile-native-mcp-server/src/index.ts
@@ -9,19 +9,20 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { SfmobileNativeTemplateDiscoveryTool } from './tools/plan/sfmobile-native-template-discovery/tool.js';
+import { UtilsXcodeAddFilesTool } from './tools/utils/utils-xcode-add-files/tool.js';
+
 import packageJson from '../package.json' with { type: 'json' };
 const version = packageJson.version;
 import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
-
-import { SfmobileNativeTemplateDiscoveryTool } from './tools/plan/sfmobile-native-template-discovery/tool.js';
 
 const server = new McpServer({
   name: 'sfdc-mobile-native-mcp-server',
   version,
 });
 
-// Define annotations
-const annotations: ToolAnnotations = {
+// Define annotations for read-only tools
+const readOnlyAnnotations: ToolAnnotations = {
   readOnlyHint: true,
   destructiveHint: false,
   idempotentHint: true,
@@ -29,10 +30,10 @@ const annotations: ToolAnnotations = {
 };
 
 // Tools will be added here when implemented
-const tools = [new SfmobileNativeTemplateDiscoveryTool()];
+const tools = [new SfmobileNativeTemplateDiscoveryTool(), new UtilsXcodeAddFilesTool(),];
 
-// Register all tools
-tools.forEach(tool => tool.register(server, annotations));
+// Register all tools with appropriate annotations
+tools.forEach(tool => tool.register(server, readOnlyAnnotations));
 
 export default server;
 

--- a/packages/mobile-native-mcp-server/src/index.ts
+++ b/packages/mobile-native-mcp-server/src/index.ts
@@ -30,7 +30,7 @@ const readOnlyAnnotations: ToolAnnotations = {
 };
 
 // Tools will be added here when implemented
-const tools = [new SfmobileNativeTemplateDiscoveryTool(), new UtilsXcodeAddFilesTool(),];
+const tools = [new SfmobileNativeTemplateDiscoveryTool(), new UtilsXcodeAddFilesTool()];
 
 // Register all tools with appropriate annotations
 tools.forEach(tool => tool.register(server, readOnlyAnnotations));

--- a/packages/mobile-native-mcp-server/src/index.ts
+++ b/packages/mobile-native-mcp-server/src/index.ts
@@ -18,8 +18,6 @@ import packageJson from '../package.json' with { type: 'json' };
 const version = packageJson.version;
 import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 
-
-
 const server = new McpServer({
   name: 'sfdc-mobile-native-mcp-server',
   version,
@@ -38,7 +36,7 @@ const tools = [
   new SfmobileNativeTemplateDiscoveryTool(),
   new SfmobileNativeBuildTool(),
   new SfmobileNativeDeploymentTool(),
-  new UtilsXcodeAddFilesTool()
+  new UtilsXcodeAddFilesTool(),
 ];
 
 // Register all tools with appropriate annotations

--- a/packages/mobile-native-mcp-server/src/tools/utils/utils-xcode-add-files/tool.ts
+++ b/packages/mobile-native-mcp-server/src/tools/utils/utils-xcode-add-files/tool.ts
@@ -76,7 +76,7 @@ export class UtilsXcodeAddFilesTool implements Tool {
   private async handleRequest(input: XcodeAddFilesInput) {
     try {
       const result = await this.addFilesToXcodeProject(input);
-      
+
       // Validate the result against the output schema
       const validatedResult = this.outputSchema.parse(result);
 

--- a/packages/mobile-native-mcp-server/src/tools/utils/utils-xcode-add-files/tool.ts
+++ b/packages/mobile-native-mcp-server/src/tools/utils/utils-xcode-add-files/tool.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { Tool } from '../../tool.js';
+import * as fs from 'fs';
+import * as path from 'path';
+import dedent from 'dedent';
+
+// Input schema for the Xcode file addition tool
+const XcodeAddFilesInputSchema = z.object({
+  projectPath: z.string().describe('Absolute path to the Xcode project directory'),
+  xcodeProjectPath: z.string().describe('Path to the .xcodeproj file (e.g., "MyApp.xcodeproj")'),
+  newFilePaths: z.array(z.string()).describe('Array of newly created file paths relative to project root'),
+  targetName: z.string().optional().describe('Optional: specific target to add files to (defaults to main app target)'),
+});
+
+type XcodeAddFilesInput = z.infer<typeof XcodeAddFilesInputSchema>;
+
+interface XcodeAddFilesResult {
+  success: boolean;
+  command: string;
+  projectPath: string;
+  filePaths: string[];
+  targetName?: string;
+  message: string;
+  error?: string;
+}
+
+export class UtilsXcodeAddFilesTool implements Tool {
+  public readonly name = 'Utils Xcode Add Files';
+  public readonly title = 'Xcode Project File Addition Utility';
+  public readonly toolId = 'utils-xcode-add-files';
+  public readonly description =
+    'Generates a Ruby command using the xcodeproj gem to add files to Xcode projects';
+  public readonly inputSchema = XcodeAddFilesInputSchema;
+
+  public register(server: McpServer, annotations: ToolAnnotations): void {
+    const enhancedAnnotations = {
+      ...annotations,
+      title: this.title,
+    };
+
+    server.tool(
+      this.toolId,
+      this.description,
+      this.inputSchema.shape,
+      enhancedAnnotations,
+      this.handleRequest.bind(this)
+    );
+  }
+
+  private async handleRequest(input: XcodeAddFilesInput) {
+    try {
+      const result = await this.addFilesToXcodeProject(input);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorResult: XcodeAddFilesResult = {
+        success: false,
+        command: '',
+        projectPath: '',
+        filePaths: [],
+        message: 'Failed to generate command for adding files to Xcode project',
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(errorResult, null, 2),
+          },
+        ],
+      };
+    }
+  }
+
+  private async addFilesToXcodeProject(input: XcodeAddFilesInput): Promise<XcodeAddFilesResult> {
+    const { projectPath, xcodeProjectPath, newFilePaths, targetName } = input;
+    
+    // Construct full path to xcodeproj file
+    const fullXcodeProjectPath = path.resolve(projectPath, xcodeProjectPath);
+    const pbxprojPath = path.join(fullXcodeProjectPath, 'project.pbxproj');
+
+    // Validate inputs
+    if (!fs.existsSync(pbxprojPath)) {
+      throw new Error(`Project file not found: ${pbxprojPath}`);
+    }
+
+    // Prepare arguments
+    const absoluteFilePaths = newFilePaths.map(filePath => 
+      path.isAbsolute(filePath) ? filePath : path.resolve(projectPath, filePath)
+    );
+
+    // Build the inline Ruby command using xcodeproj gem
+    const rubyCode = this.buildInlineRubyCode(fullXcodeProjectPath, targetName, absoluteFilePaths);
+    const command = `ruby -e "${rubyCode}"`;
+    
+    return {
+      success: true,
+      command,
+      projectPath: fullXcodeProjectPath,
+      filePaths: absoluteFilePaths,
+      targetName,
+      message: `Generated command to add ${newFilePaths.length} files to Xcode project`
+    };
+  }
+
+  private buildInlineRubyCode(projectPath: string, targetName: string | undefined, filePaths: string[]): string {
+    // Escape strings for shell
+    const escapeForShell = (str: string) => str.replace(/"/g, '\\"').replace(/'/g, "\\'");
+    
+    const escapedProjectPath = escapeForShell(projectPath);
+    const escapedTargetName = targetName ? `'${escapeForShell(targetName)}'` : 'nil';
+    const escapedFilePaths = filePaths.map(fp => `'${escapeForShell(fp)}'`).join(', ');
+
+    return dedent`
+      require 'xcodeproj'
+      require 'json'
+      require 'pathname'
+
+      begin
+        project_path = '${escapedProjectPath}'
+        target_name = ${escapedTargetName}
+        files_to_add = [${escapedFilePaths}]
+
+        unless File.exist?(project_path)
+          puts JSON.generate({
+            success: false,
+            error: 'Project file not found',
+            message: "Could not find Xcode project at #{project_path}"
+          })
+          exit 1
+        end
+
+        project = Xcodeproj::Project.open(project_path)
+        target = target_name ? project.targets.find { |t| t.name == target_name } : project.targets.first
+
+        unless target
+          puts JSON.generate({
+            success: false,
+            error: 'Target not found',
+            message: target_name ? "Could not find target '#{target_name}'" : 'No targets found in project'
+          })
+          exit 1
+        end
+
+        files_added = []
+        files_failed = []
+
+        files_to_add.each do |file_path|
+          unless File.exist?(file_path)
+            files_failed << file_path
+            next
+          end
+
+          begin
+            project_dir = File.dirname(project_path)
+            relative_path = Pathname.new(file_path).relative_path_from(Pathname.new(project_dir)).to_s
+            file_ref = project.main_group.new_file(relative_path)
+            
+            file_ext = File.extname(file_path).downcase
+            source_extensions = ['.swift', '.m', '.mm', '.c', '.cpp', '.cc', '.cxx']
+            
+            if source_extensions.include?(file_ext)
+              target.source_build_phase.add_file_reference(file_ref)
+            end
+            
+            files_added << File.basename(file_path)
+          rescue => e
+            files_failed << "#{file_path}: #{e.message}"
+          end
+        end
+
+        project.save
+
+        result = {
+          success: true,
+          filesAdded: files_added,
+          target: target.name,
+          buildStatus: 'completed',
+          message: "Successfully added #{files_added.length} files to Xcode project"
+        }
+        
+        if files_failed.any?
+          result[:warnings] = "Failed to add #{files_failed.length} files: #{files_failed.join(', ')}"
+        end
+
+        puts JSON.generate(result)
+
+      rescue => e
+        puts JSON.generate({
+          success: false,
+          error: e.class.name,
+          message: e.message
+        })
+        exit 1
+      end
+    `;
+  }
+}

--- a/packages/mobile-native-mcp-server/tests/tools/utils/utils-xcode-add-files/tool.test.ts
+++ b/packages/mobile-native-mcp-server/tests/tools/utils/utils-xcode-add-files/tool.test.ts
@@ -87,7 +87,13 @@ describe('UtilsXcodeAddFilesTool', () => {
 
     beforeEach(() => {
       // Mock project.pbxproj file exists
-      const expectedPath = path.resolve('path', 'to', 'project', 'MyApp.xcodeproj', 'project.pbxproj');
+      const expectedPath = path.resolve(
+        'path',
+        'to',
+        'project',
+        'MyApp.xcodeproj',
+        'project.pbxproj'
+      );
       mockFs.existsSync.mockImplementation(filePath => {
         return path.resolve(filePath as string) === expectedPath;
       });
@@ -104,7 +110,9 @@ describe('UtilsXcodeAddFilesTool', () => {
       expect(parsedResult.success).toBe(true);
       expect(parsedResult.command).toContain('ruby -e');
       expect(parsedResult.command).toContain("require 'xcodeproj'");
-      expect(path.resolve(parsedResult.projectPath)).toBe(path.resolve('path', 'to', 'project', 'MyApp.xcodeproj'));
+      expect(path.resolve(parsedResult.projectPath)).toBe(
+        path.resolve('path', 'to', 'project', 'MyApp.xcodeproj')
+      );
       expect(parsedResult.filePaths.map((p: string) => path.resolve(p))).toEqual([
         path.resolve('path', 'to', 'project', 'ContactManager.swift'),
         path.resolve('path', 'to', 'project', 'ContactView.swift'),
@@ -116,7 +124,10 @@ describe('UtilsXcodeAddFilesTool', () => {
     it('should handle absolute file paths', async () => {
       const inputWithAbsolutePaths = {
         ...validInput,
-        newFilePaths: [path.resolve('absolute', 'path', 'ContactManager.swift'), 'relative/ContactView.swift'],
+        newFilePaths: [
+          path.resolve('absolute', 'path', 'ContactManager.swift'),
+          'relative/ContactView.swift',
+        ],
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -200,7 +211,7 @@ describe('UtilsXcodeAddFilesTool', () => {
     it('should handle string escaping in Ruby command', async () => {
       const inputWithSpecialChars = {
         ...validInput,
-        projectPath: path.resolve('path', 'with\'quotes', 'and"double'),
+        projectPath: path.resolve('path', "with'quotes", 'and"double'),
         newFilePaths: ["File'With'Quotes.swift"],
       };
 
@@ -272,7 +283,9 @@ describe('UtilsXcodeAddFilesTool', () => {
       const result = await (tool as any).handleRequest(input);
 
       const parsedResult = JSON.parse(result.content[0].text);
-      expect(path.resolve(parsedResult.projectPath)).toBe(path.resolve('base', 'project', 'subdir', 'MyApp.xcodeproj'));
+      expect(path.resolve(parsedResult.projectPath)).toBe(
+        path.resolve('base', 'project', 'subdir', 'MyApp.xcodeproj')
+      );
     });
 
     it('should handle absolute xcodeproj path', async () => {

--- a/packages/mobile-native-mcp-server/tests/tools/utils/utils-xcode-add-files/tool.test.ts
+++ b/packages/mobile-native-mcp-server/tests/tools/utils/utils-xcode-add-files/tool.test.ts
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { UtilsXcodeAddFilesTool } from '../../../../src/tools/utils/utils-xcode-add-files/tool.js';
+import * as fs from 'fs';
+
+// Mock fs module
+vi.mock('fs');
+const mockFs = vi.mocked(fs);
+
+describe('UtilsXcodeAddFilesTool', () => {
+  let tool: UtilsXcodeAddFilesTool;
+
+  beforeEach(() => {
+    tool = new UtilsXcodeAddFilesTool();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('Tool Properties', () => {
+    it('should have correct tool properties', () => {
+      expect(tool.name).toBe('Utils Xcode Add Files');
+      expect(tool.title).toBe('Xcode Project File Addition Utility');
+      expect(tool.toolId).toBe('utils-xcode-add-files');
+      expect(tool.description).toBe(
+        'Generates a Ruby command using the xcodeproj gem to add files to Xcode projects'
+      );
+    });
+
+    it('should have input schema with required fields', () => {
+      const schema = tool.inputSchema;
+      expect(schema).toBeDefined();
+      expect(schema.shape).toBeDefined();
+      expect(schema.shape.projectPath).toBeDefined();
+      expect(schema.shape.xcodeProjectPath).toBeDefined();
+      expect(schema.shape.newFilePaths).toBeDefined();
+      expect(schema.shape.targetName).toBeDefined();
+    });
+  });
+
+  describe('Tool Registration', () => {
+    it('should register with MCP server', () => {
+      const mockServer = {
+        tool: vi.fn(),
+      };
+      const mockAnnotations = {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: false,
+        openWorldHint: false,
+      };
+
+      tool.register(
+        mockServer as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer,
+        mockAnnotations
+      );
+
+      expect(mockServer.tool).toHaveBeenCalledWith(
+        'utils-xcode-add-files',
+        'Generates a Ruby command using the xcodeproj gem to add files to Xcode projects',
+        expect.any(Object),
+        expect.objectContaining({
+          ...mockAnnotations,
+          title: 'Xcode Project File Addition Utility',
+        }),
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('Command Generation', () => {
+    const validInput = {
+      projectPath: '/path/to/project',
+      xcodeProjectPath: 'MyApp.xcodeproj',
+      newFilePaths: ['ContactManager.swift', 'ContactView.swift'],
+      targetName: 'MyApp',
+    };
+
+    beforeEach(() => {
+      // Mock project.pbxproj file exists
+      mockFs.existsSync.mockImplementation((filePath) => {
+        return filePath === '/path/to/project/MyApp.xcodeproj/project.pbxproj';
+      });
+    });
+
+    it('should generate Ruby command successfully', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(validInput);
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.success).toBe(true);
+      expect(parsedResult.command).toContain('ruby -e');
+      expect(parsedResult.command).toContain("require 'xcodeproj'");
+      expect(parsedResult.projectPath).toBe('/path/to/project/MyApp.xcodeproj');
+      expect(parsedResult.filePaths).toEqual([
+        '/path/to/project/ContactManager.swift',
+        '/path/to/project/ContactView.swift'
+      ]);
+      expect(parsedResult.targetName).toBe('MyApp');
+      expect(parsedResult.message).toBe('Generated command to add 2 files to Xcode project');
+    });
+
+    it('should handle absolute file paths', async () => {
+      const inputWithAbsolutePaths = {
+        ...validInput,
+        newFilePaths: ['/absolute/path/ContactManager.swift', 'relative/ContactView.swift'],
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(inputWithAbsolutePaths);
+      
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.success).toBe(true);
+      expect(parsedResult.filePaths).toEqual([
+        '/absolute/path/ContactManager.swift',
+        '/path/to/project/relative/ContactView.swift'
+      ]);
+    });
+
+    it('should handle optional targetName', async () => {
+      const inputWithoutTarget = {
+        projectPath: '/path/to/project',
+        xcodeProjectPath: 'MyApp.xcodeproj',
+        newFilePaths: ['ContactManager.swift'],
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(inputWithoutTarget);
+      
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.success).toBe(true);
+      expect(parsedResult.targetName).toBeUndefined();
+      expect(parsedResult.command).toContain('target_name = nil');
+    });
+  });
+
+  describe('Ruby Command Content', () => {
+    const validInput = {
+      projectPath: '/path/to/project',
+      xcodeProjectPath: 'MyApp.xcodeproj',
+      newFilePaths: ['ContactManager.swift'],
+      targetName: 'MyApp',
+    };
+
+    beforeEach(() => {
+      mockFs.existsSync.mockReturnValue(true);
+    });
+
+    it('should generate Ruby command with proper structure', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(validInput);
+      
+      const parsedResult = JSON.parse(result.content[0].text);
+      const command = parsedResult.command;
+
+      // Check for required Ruby gems
+      expect(command).toContain("require 'xcodeproj'");
+      expect(command).toContain("require 'json'");
+      expect(command).toContain("require 'pathname'");
+
+      // Check for project operations
+      expect(command).toContain('Xcodeproj::Project.open');
+      expect(command).toContain('project.main_group.new_file');
+      expect(command).toContain('target.source_build_phase.add_file_reference');
+      expect(command).toContain('project.save');
+
+      // Check for error handling
+      expect(command).toContain('rescue => e');
+      expect(command).toContain('JSON.generate');
+    });
+
+    it('should include file type detection logic', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(validInput);
+      
+      const parsedResult = JSON.parse(result.content[0].text);
+      const command = parsedResult.command;
+
+      expect(command).toContain('source_extensions = [');
+      expect(command).toContain("'.swift'");
+      expect(command).toContain("'.m'");
+      expect(command).toContain("'.mm'");
+      expect(command).toContain("'.c'");
+      expect(command).toContain("'.cpp'");
+    });
+
+    it('should handle string escaping in Ruby command', async () => {
+      const inputWithSpecialChars = {
+        ...validInput,
+        projectPath: "/path/with'quotes/and\"double",
+        newFilePaths: ["File'With'Quotes.swift"],
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(inputWithSpecialChars);
+      
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.success).toBe(true);
+      
+      const command = parsedResult.command;
+      expect(command).toContain("\\'"); // Escaped single quotes
+      expect(command).toContain('\\"'); // Escaped double quotes
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should return error when project file does not exist', async () => {
+      mockFs.existsSync.mockReturnValue(false);
+
+      const input = {
+        projectPath: '/nonexistent/project',
+        xcodeProjectPath: 'MyApp.xcodeproj',
+        newFilePaths: ['ContactManager.swift'],
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.isError).toBe(true);
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.success).toBe(false);
+      expect(parsedResult.error).toContain('Project file not found');
+    });
+
+    it('should handle internal errors gracefully', async () => {
+      mockFs.existsSync.mockImplementation(() => {
+        throw new Error('File system error');
+      });
+
+      const input = {
+        projectPath: '/path/to/project',
+        xcodeProjectPath: 'MyApp.xcodeproj',
+        newFilePaths: ['ContactManager.swift'],
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.isError).toBe(true);
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.success).toBe(false);
+      expect(parsedResult.error).toBe('File system error');
+    });
+  });
+
+  describe('Path Resolution', () => {
+    beforeEach(() => {
+      mockFs.existsSync.mockReturnValue(true);
+    });
+
+    it('should resolve relative xcodeproj path correctly', async () => {
+      const input = {
+        projectPath: '/base/project',
+        xcodeProjectPath: 'subdir/MyApp.xcodeproj',
+        newFilePaths: ['ContactManager.swift'],
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+      
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.projectPath).toBe('/base/project/subdir/MyApp.xcodeproj');
+    });
+
+    it('should handle absolute xcodeproj path', async () => {
+      const input = {
+        projectPath: '/base/project',
+        xcodeProjectPath: '/absolute/path/MyApp.xcodeproj',
+        newFilePaths: ['ContactManager.swift'],
+      };
+
+      // Mock the absolute path exists
+      mockFs.existsSync.mockImplementation((filePath) => {
+        return filePath === '/absolute/path/MyApp.xcodeproj/project.pbxproj';
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+      
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.projectPath).toBe('/absolute/path/MyApp.xcodeproj');
+    });
+  });
+});

--- a/packages/mobile-native-mcp-server/tests/tools/utils/utils-xcode-add-files/tool.test.ts
+++ b/packages/mobile-native-mcp-server/tests/tools/utils/utils-xcode-add-files/tool.test.ts
@@ -86,7 +86,7 @@ describe('UtilsXcodeAddFilesTool', () => {
 
     beforeEach(() => {
       // Mock project.pbxproj file exists
-      mockFs.existsSync.mockImplementation((filePath) => {
+      mockFs.existsSync.mockImplementation(filePath => {
         return filePath === '/path/to/project/MyApp.xcodeproj/project.pbxproj';
       });
     });
@@ -97,7 +97,7 @@ describe('UtilsXcodeAddFilesTool', () => {
 
       expect(result.content).toBeDefined();
       expect(result.content[0].type).toBe('text');
-      
+
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.success).toBe(true);
       expect(parsedResult.command).toContain('ruby -e');
@@ -105,7 +105,7 @@ describe('UtilsXcodeAddFilesTool', () => {
       expect(parsedResult.projectPath).toBe('/path/to/project/MyApp.xcodeproj');
       expect(parsedResult.filePaths).toEqual([
         '/path/to/project/ContactManager.swift',
-        '/path/to/project/ContactView.swift'
+        '/path/to/project/ContactView.swift',
       ]);
       expect(parsedResult.targetName).toBe('MyApp');
       expect(parsedResult.message).toBe('Generated command to add 2 files to Xcode project');
@@ -119,12 +119,12 @@ describe('UtilsXcodeAddFilesTool', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (tool as any).handleRequest(inputWithAbsolutePaths);
-      
+
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.success).toBe(true);
       expect(parsedResult.filePaths).toEqual([
         '/absolute/path/ContactManager.swift',
-        '/path/to/project/relative/ContactView.swift'
+        '/path/to/project/relative/ContactView.swift',
       ]);
     });
 
@@ -137,7 +137,7 @@ describe('UtilsXcodeAddFilesTool', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (tool as any).handleRequest(inputWithoutTarget);
-      
+
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.success).toBe(true);
       expect(parsedResult.targetName).toBeUndefined();
@@ -160,7 +160,7 @@ describe('UtilsXcodeAddFilesTool', () => {
     it('should generate Ruby command with proper structure', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (tool as any).handleRequest(validInput);
-      
+
       const parsedResult = JSON.parse(result.content[0].text);
       const command = parsedResult.command;
 
@@ -183,7 +183,7 @@ describe('UtilsXcodeAddFilesTool', () => {
     it('should include file type detection logic', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (tool as any).handleRequest(validInput);
-      
+
       const parsedResult = JSON.parse(result.content[0].text);
       const command = parsedResult.command;
 
@@ -198,16 +198,16 @@ describe('UtilsXcodeAddFilesTool', () => {
     it('should handle string escaping in Ruby command', async () => {
       const inputWithSpecialChars = {
         ...validInput,
-        projectPath: "/path/with'quotes/and\"double",
+        projectPath: '/path/with\'quotes/and"double',
         newFilePaths: ["File'With'Quotes.swift"],
       };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (tool as any).handleRequest(inputWithSpecialChars);
-      
+
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.success).toBe(true);
-      
+
       const command = parsedResult.command;
       expect(command).toContain("\\'"); // Escaped single quotes
       expect(command).toContain('\\"'); // Escaped double quotes
@@ -268,7 +268,7 @@ describe('UtilsXcodeAddFilesTool', () => {
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (tool as any).handleRequest(input);
-      
+
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.projectPath).toBe('/base/project/subdir/MyApp.xcodeproj');
     });
@@ -281,13 +281,13 @@ describe('UtilsXcodeAddFilesTool', () => {
       };
 
       // Mock the absolute path exists
-      mockFs.existsSync.mockImplementation((filePath) => {
+      mockFs.existsSync.mockImplementation(filePath => {
         return filePath === '/absolute/path/MyApp.xcodeproj/project.pbxproj';
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const result = await (tool as any).handleRequest(input);
-      
+
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.projectPath).toBe('/absolute/path/MyApp.xcodeproj');
     });

--- a/vitest.config.base.mts
+++ b/vitest.config.base.mts
@@ -39,6 +39,7 @@ export default defineConfig({
         '**/index.ts',
         '**/coverage/',
         '**/update-type-declarations.ts',
+        '**/tools/tool.ts', // Interface-only file with no executable code
       ],
 
       // Files to include in coverage reporting


### PR DESCRIPTION
# Add Utils Xcode Add Files MCP Tool

## Summary
Implements a new MCP tool that generates Ruby commands using the xcodeproj gem to add files to Xcode projects. This addresses the common issue where LLMs create new Swift/Objective-C files but forget to add them to the Xcode project, causing compilation errors.

## Key Features
- **Reliable xcodeproj gem integration** - Uses the same library as CocoaPods for robust project manipulation
- **Smart file type detection** - Automatically adds source files (.swift, .m, .mm, etc.) to build phases
- **Comprehensive error handling** - Validates projects, targets, and file paths with detailed feedback
- **Transparent command generation** - Returns Ruby commands for review before execution
- **Flexible target selection** - Supports specific target selection or defaults to main app target


Fixes the workflow gap where generated iOS files aren't properly integrated into Xcode projects.