### PR TITLE
Add Mobile Native Deployment Tool for Salesforce App Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ MCP server providing comprehensive tooling support for Salesforce Mobile Native 
 
 - **Template Discovery**: Tools for discovering and selecting appropriate native mobile app templates for iOS and Android platforms
 - **Project Planning**: Guidance for template selection based on platform requirements and feature keywords
+- **App Deployment**: Comprehensive deployment guidance for iOS and Android apps including build, deployment, and verification steps
 - **SDK Integration**: Integration with Salesforce Mobile SDK plugin for native app development
 
 **Installation**: `npx -y @salesforce/mobile-native-mcp-server`

--- a/package-lock.json
+++ b/package-lock.json
@@ -3514,6 +3514,10 @@
       "resolved": "packages/evaluation",
       "link": true
     },
+    "node_modules/@salesforce/mobile-native-mcp-server": {
+      "resolved": "packages/mobile-native-mcp-server",
+      "link": true
+    },
     "node_modules/@salesforce/mobile-web-mcp-server": {
       "resolved": "packages/mobile-web",
       "link": true
@@ -10187,6 +10191,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/mobile-native-mcp-server": {
+      "name": "@salesforce/mobile-native-mcp-server",
+      "version": "0.0.1-alpha.1",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.13.2",
+        "dedent": "^1.5.1",
+        "zod": "^3.25.67"
+      },
+      "bin": {
+        "sfdc-mobile-native-mcp-server": "dist/index.js"
+      },
+      "devDependencies": {
+        "@modelcontextprotocol/inspector": "^0.16.1",
+        "@types/node": "^24.0.7",
+        "@vitest/coverage-v8": "^3.2.4",
+        "tsx": "^4.19.2",
+        "typescript": "^5.8.3",
+        "vitest": "^3.2.3"
       }
     },
     "packages/mobile-web": {

--- a/packages/mobile-native-mcp-server/package.json
+++ b/packages/mobile-native-mcp-server/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.13.2",
+    "dedent": "^1.5.1",
     "zod": "^3.25.67"
   },
   "devDependencies": {

--- a/packages/mobile-native-mcp-server/src/index.ts
+++ b/packages/mobile-native-mcp-server/src/index.ts
@@ -14,6 +14,7 @@ const version = packageJson.version;
 import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 
 import { SfmobileNativeTemplateDiscoveryTool } from './tools/plan/sfmobile-native-template-discovery/tool.js';
+import { SfmobileNativeDeploymentTool } from './tools/run/sfmobile-native-deployment/tool.js';
 
 const server = new McpServer({
   name: 'sfdc-mobile-native-mcp-server',
@@ -29,7 +30,7 @@ const annotations: ToolAnnotations = {
 };
 
 // Tools will be added here when implemented
-const tools = [new SfmobileNativeTemplateDiscoveryTool()];
+const tools = [new SfmobileNativeTemplateDiscoveryTool(), new SfmobileNativeDeploymentTool()];
 
 // Register all tools
 tools.forEach(tool => tool.register(server, annotations));

--- a/packages/mobile-native-mcp-server/src/tools/run/sfmobile-native-deployment/tool.ts
+++ b/packages/mobile-native-mcp-server/src/tools/run/sfmobile-native-deployment/tool.ts
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import dedent from 'dedent';
+import { Tool } from '../../tool.js';
+
+// Input schema for the deployment tool
+const DeploymentInputSchema = z.object({
+  platform: z.enum(['iOS', 'Android']).describe('Target mobile platform'),
+  projectPath: z.string().describe('Path to the mobile project directory'),
+  buildType: z.enum(['debug', 'release']).default('debug').describe('Build type for deployment'),
+  targetDevice: z.string().optional().describe('Target device identifier (optional)'),
+});
+
+type DeploymentInput = z.infer<typeof DeploymentInputSchema>;
+
+export class SfmobileNativeDeploymentTool implements Tool {
+  public readonly name = 'Salesforce Mobile Native Deployment';
+  public readonly title = 'Salesforce Mobile Native Deployment Guide';
+  public readonly toolId = 'sfmobile-native-deployment';
+  public readonly description =
+    'Guides LLM through deploying Salesforce mobile native apps to devices or simulators';
+  public readonly inputSchema = DeploymentInputSchema;
+
+  public register(server: McpServer, annotations: ToolAnnotations): void {
+    const enhancedAnnotations = {
+      ...annotations,
+      title: this.title,
+    };
+
+    server.tool(
+      this.toolId,
+      this.description,
+      this.inputSchema.shape,
+      enhancedAnnotations,
+      this.handleRequest.bind(this)
+    );
+  }
+
+  private async handleRequest(input: DeploymentInput) {
+    try {
+      // Parse the input to ensure defaults are applied
+      const parsedInput = this.inputSchema.parse(input);
+      const guidance = this.generateDeploymentGuidance(parsedInput);
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: guidance,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text' as const,
+            text: `Error: ${error instanceof Error ? error.message : 'Unknown error occurred'}`,
+          },
+        ],
+      };
+    }
+  }
+
+  private generateDeploymentGuidance(input: DeploymentInput): string {
+    return dedent`
+      You are a technology-adept agent working on behalf of a user who has less familiarity with the technical details of application deployment than you do, and needs your assistance to deploy the app to the target device.
+      Please execute the instructions of the following plan on behalf of the user, providing them information on the outcomes that they may need to know.
+
+      # Mobile Native App Deployment Guidance for ${input.platform}
+
+      First make sure \`sfmobile-native-build\` mcp tool is executed successfully. If not, run the \`sfmobile-native-build\` tool first.
+
+      You MUST follow the steps in this guide in order. Do not execute any commands that are not part of the steps in this guide.
+
+      ${this.generateTargetDeviceReadyStep(1, input)}
+
+      ${this.generateDeploymentStep(2, input)}
+
+      ${this.generateNextStep(input)}
+    `;
+  }
+
+  private generateTargetDeviceReadyStep(stepNumber: number, input: DeploymentInput): string {
+    return dedent`
+      ## Step ${stepNumber}: ${input.platform === 'iOS' ? 'iOS Simulator' : 'Android Emulator'} must be ready
+      
+      ${
+        input.platform === 'iOS'
+          ? this.generateTargetDeviceReadyStepIOS(input)
+          : this.generateTargetDeviceReadyStepAdndroid(input)
+      }
+    `;
+  }
+
+  private generateTargetDeviceReadyStepIOS(input: DeploymentInput): string {
+    return dedent`
+      Navigate to the ${input.projectPath} directory and run the following command to check if the simulator is running:
+
+      \`\`\`bash
+      xcrun simctl list devices | grep "${input.targetDevice}"
+      \`\`\`
+
+      If (Shutdown) is shown as the output, the simulator is not running. Start it by running the following command:
+
+      \`\`\`bash
+      xcrun simctl boot ${input.targetDevice}
+      \`\`\`
+    `;
+  }
+
+  private generateTargetDeviceReadyStepAdndroid(input: DeploymentInput): string {
+    return dedent`
+      Navigate to the ${input.projectPath} directory and run the following commands to make sure 
+      an emulator with an API level equal to or higher than the app's minimum SDK version is active.
+
+      First, make sure an emulator is configured. If not, run the following command to create a new emulator:
+      \`\`\`bash
+      sf force lightning local device list -p android
+      \`\`\`
+
+      If an emulator hasn't been set up yet, use the following command to create one:
+      \`\`\`bash
+      sf force lightning local device create -p android -n pixel-<api-level> -d pixel -l <api-level>
+      \`\`\`
+
+      Replace <api-level> with the value of minSdk from the application's build gradle file.
+
+      Second, get the emulator to use by running the following command:
+      \`\`\`bash
+      sf force lightning local device list -p android
+      \`\`\`
+      
+      Third, start the emulator by running the following command:
+      \`\`\`bash
+      sf force lightning local device start -p android -t <emulator-name>
+      \`\`\`
+    `;
+  }
+
+  private generateDeploymentStep(stepNumber: number, input: DeploymentInput): string {
+    return dedent`
+      ## Step ${stepNumber}: Deploy application to ${input.platform === 'iOS' ? 'iOS Simulator' : 'Android Emulator'}
+
+      Deploy the application to the target device using:
+
+      \`\`\`bash
+      ${this.generateDeploymentCommand(input)}
+      \`\`\`
+    `;
+  }
+
+  private generateDeploymentCommand(input: DeploymentInput): string {
+    return input.platform === 'iOS'
+      ? dedent`
+        \`\`\`bash
+        xcrun simctl install ${input.targetDevice} <your-app>.app
+        \`\`\`
+
+        Replace <your-app>.app with app name built in \`sfmobile-native-build\` tool call.
+      `
+      : dedent`
+        \`\`\`bash
+        ./gradlew install${input.buildType === 'release' ? 'Release' : 'Debug'}
+        \`\`\`
+      `;
+  }
+
+  private generateNextStep(input: DeploymentInput): string {
+    return dedent`
+      ## Next Steps
+
+      Once the app is deployed successfully, you can launch the app on the target device by running the following command:
+      ${this.generateLaunchCommand(input)}
+    `;
+  }
+
+  private generateLaunchCommand(input: DeploymentInput): string {
+    return input.platform === 'iOS'
+      ? dedent`
+        \`\`\`bash
+        xcrun simctl launch ${input.targetDevice} <app-bundle-id>
+        \`\`\`
+        Replace <app-bundle-id> with the bundle id of the app.
+      `
+      : dedent`
+        \`\`\`bash
+        adb shell monkey -p <application-id> -c android.intent.category.LAUNCHER 1
+        \`\`\`
+        Replace <application-id> with the value of applicationId from the application's build gradle file.
+      `;
+  }
+}

--- a/packages/mobile-native-mcp-server/tests/tools/run/sfmobile-native-deployment/tool.test.ts
+++ b/packages/mobile-native-mcp-server/tests/tools/run/sfmobile-native-deployment/tool.test.ts
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SfmobileNativeDeploymentTool } from '../../../../src/tools/run/sfmobile-native-deployment/tool.js';
+
+describe('SfmobileNativeDeploymentTool', () => {
+  let tool: SfmobileNativeDeploymentTool;
+
+  beforeEach(() => {
+    tool = new SfmobileNativeDeploymentTool();
+  });
+
+  it('should have correct tool properties', () => {
+    expect(tool.name).toBe('Salesforce Mobile Native Deployment');
+    expect(tool.title).toBe('Salesforce Mobile Native Deployment Guide');
+    expect(tool.toolId).toBe('sfmobile-native-deployment');
+    expect(tool.description).toBe(
+      'Guides LLM through deploying Salesforce mobile native apps to devices or simulators'
+    );
+  });
+
+  it('should have input schema with required fields', () => {
+    const schema = tool.inputSchema;
+    expect(schema).toBeDefined();
+    expect(schema.shape).toBeDefined();
+    expect(schema.shape.platform).toBeDefined();
+    expect(schema.shape.projectPath).toBeDefined();
+    expect(schema.shape.buildType).toBeDefined();
+    expect(schema.shape.targetDevice).toBeDefined();
+  });
+
+  it('should register with MCP server', () => {
+    const mockServer = {
+      tool: vi.fn(),
+    };
+    const mockAnnotations = {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    };
+
+    tool.register(
+      mockServer as unknown as import('@modelcontextprotocol/sdk/server/mcp.js').McpServer,
+      mockAnnotations
+    );
+
+    expect(mockServer.tool).toHaveBeenCalledWith(
+      'sfmobile-native-deployment',
+      'Guides LLM through deploying Salesforce mobile native apps to devices or simulators',
+      expect.any(Object),
+      expect.objectContaining({
+        ...mockAnnotations,
+        title: 'Salesforce Mobile Native Deployment Guide',
+      }),
+      expect.any(Function)
+    );
+  });
+
+  describe('iOS deployment guidance', () => {
+    it('should generate guidance for iOS with debug build', async () => {
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'iPhone-15-Pro',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Mobile Native App Deployment Guidance for iOS');
+      expect(result.content[0].text).toContain('Step 1: iOS Simulator must be ready');
+      expect(result.content[0].text).toContain('Step 2: Deploy application to iOS Simulator');
+      expect(result.content[0].text).toContain('xcrun simctl list devices | grep "iPhone-15-Pro"');
+      expect(result.content[0].text).toContain('xcrun simctl boot iPhone-15-Pro');
+      expect(result.content[0].text).toContain('xcrun simctl install iPhone-15-Pro <your-app>.app');
+      expect(result.content[0].text).toContain('xcrun simctl launch iPhone-15-Pro <app-bundle-id>');
+    });
+
+    it('should generate guidance for iOS with release build', async () => {
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'release' as const,
+        targetDevice: 'iPhone-15-Pro',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Mobile Native App Deployment Guidance for iOS');
+    });
+
+    it('should generate guidance for iOS without target device', async () => {
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Mobile Native App Deployment Guidance for iOS');
+    });
+  });
+
+  describe('Android deployment guidance', () => {
+    it('should generate guidance for Android with debug build', async () => {
+      const input = {
+        platform: 'Android' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'pixel-34',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Mobile Native App Deployment Guidance for Android');
+      expect(result.content[0].text).toContain('Step 1: Android Emulator must be ready');
+      expect(result.content[0].text).toContain('Step 2: Deploy application to Android Emulator');
+      expect(result.content[0].text).toContain('sf force lightning local device list -p android');
+      expect(result.content[0].text).toContain('sf force lightning local device create -p android');
+      expect(result.content[0].text).toContain('sf force lightning local device start -p android');
+      expect(result.content[0].text).toContain('./gradlew installDebug');
+      expect(result.content[0].text).toContain('adb shell monkey -p <application-id>');
+    });
+
+    it('should generate guidance for Android with release build', async () => {
+      const input = {
+        platform: 'Android' as const,
+        projectPath: '/path/to/project',
+        buildType: 'release' as const,
+        targetDevice: 'pixel-34',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Mobile Native App Deployment Guidance for Android');
+      expect(result.content[0].text).toContain('./gradlew installRelease');
+    });
+
+    it('should generate guidance for Android without target device', async () => {
+      const input = {
+        platform: 'Android' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Mobile Native App Deployment Guidance for Android');
+    });
+  });
+
+  describe('input validation', () => {
+    it('should apply default buildType when not provided', async () => {
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Mobile Native App Deployment Guidance for iOS');
+    });
+
+    it('should handle invalid platform gracefully', async () => {
+      const input = {
+        platform: 'InvalidPlatform' as any,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error:');
+    });
+
+    it('should handle missing required fields', async () => {
+      const input = {
+        platform: 'iOS' as const,
+        // Missing projectPath
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error:');
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle errors gracefully', async () => {
+      // Mock the generateDeploymentGuidance to throw an error
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const originalMethod = (tool as any).generateDeploymentGuidance;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (tool as any).generateDeploymentGuidance = () => {
+        throw new Error('Test error');
+      };
+
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error: Test error');
+
+      // Restore original method
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (tool as any).generateDeploymentGuidance = originalMethod;
+    });
+
+    it('should handle unknown errors', async () => {
+      // Mock the generateDeploymentGuidance to throw a non-Error object
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const originalMethod = (tool as any).generateDeploymentGuidance;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (tool as any).generateDeploymentGuidance = () => {
+        throw 'String error';
+      };
+
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (tool as any).handleRequest(input);
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Error: Unknown error occurred');
+
+      // Restore original method
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (tool as any).generateDeploymentGuidance = originalMethod;
+    });
+  });
+
+  describe('private method testing', () => {
+    it('should generate correct iOS target device ready step', () => {
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'iPhone-15-Pro',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (tool as any).generateTargetDeviceReadyStep(1, input);
+
+      expect(result).toContain('Step 1: iOS Simulator must be ready');
+      expect(result).toContain('xcrun simctl list devices | grep "iPhone-15-Pro"');
+      expect(result).toContain('xcrun simctl boot iPhone-15-Pro');
+    });
+
+    it('should generate correct Android target device ready step', () => {
+      const input = {
+        platform: 'Android' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'pixel-34',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (tool as any).generateTargetDeviceReadyStep(1, input);
+
+      expect(result).toContain('Step 1: Android Emulator must be ready');
+      expect(result).toContain('sf force lightning local device list -p android');
+      expect(result).toContain('sf force lightning local device create -p android');
+    });
+
+    it('should generate correct deployment step', () => {
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'iPhone-15-Pro',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (tool as any).generateDeploymentStep(2, input);
+
+      expect(result).toContain('Step 2: Deploy application to iOS Simulator');
+      expect(result).toContain('xcrun simctl install iPhone-15-Pro <your-app>.app');
+    });
+
+    it('should generate correct iOS deployment command', () => {
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'iPhone-15-Pro',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (tool as any).generateDeploymentCommand(input);
+
+      expect(result).toContain('xcrun simctl install iPhone-15-Pro <your-app>.app');
+      expect(result).toContain('Replace <your-app>.app with app name built in');
+    });
+
+    it('should generate correct Android deployment command for debug', () => {
+      const input = {
+        platform: 'Android' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'pixel-34',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (tool as any).generateDeploymentCommand(input);
+
+      expect(result).toContain('./gradlew installDebug');
+    });
+
+    it('should generate correct Android deployment command for release', () => {
+      const input = {
+        platform: 'Android' as const,
+        projectPath: '/path/to/project',
+        buildType: 'release' as const,
+        targetDevice: 'pixel-34',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (tool as any).generateDeploymentCommand(input);
+
+      expect(result).toContain('./gradlew installRelease');
+    });
+
+    it('should generate correct iOS launch command', () => {
+      const input = {
+        platform: 'iOS' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'iPhone-15-Pro',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (tool as any).generateLaunchCommand(input);
+
+      expect(result).toContain('xcrun simctl launch iPhone-15-Pro <app-bundle-id>');
+      expect(result).toContain('Replace <app-bundle-id> with the bundle id of the app');
+    });
+
+    it('should generate correct Android launch command', () => {
+      const input = {
+        platform: 'Android' as const,
+        projectPath: '/path/to/project',
+        buildType: 'debug' as const,
+        targetDevice: 'pixel-34',
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (tool as any).generateLaunchCommand(input);
+
+      expect(result).toContain('adb shell monkey -p <application-id>');
+      expect(result).toContain('Replace <application-id> with the value of applicationId');
+    });
+  });
+});


### PR DESCRIPTION
Add deployment mcp tool into mobile native mcp server.

- tool added for facilitate deploying app to emulator or simulator.
- tests
- docs
