### PR TITLE
Updating permissions for OIDC NPM tokens

### DIFF
--- a/.github/workflows/base-publish-release.yml
+++ b/.github/workflows/base-publish-release.yml
@@ -53,7 +53,6 @@ jobs:
       - name: Publish release using orchestrator
         uses: actions/github-script@v7
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           script: |

--- a/.github/workflows/mcp-workflow-publish-release.yml
+++ b/.github/workflows/mcp-workflow-publish-release.yml
@@ -35,5 +35,6 @@ jobs:
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
     permissions:
+      id-token: write # Required for OIDC
       contents: write
       packages: write

--- a/.github/workflows/mobile-native-mcp-server-publish-release.yml
+++ b/.github/workflows/mobile-native-mcp-server-publish-release.yml
@@ -35,5 +35,6 @@ jobs:
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit
     permissions:
+      id-token: write # Required for OIDC
       contents: write
       packages: write


### PR DESCRIPTION
### What does this PR do?

Our NPM publishing token has expired, and the goal is to move to OIDC-based token creation for security. See https://docs.npmjs.com/trusted-publishers. These permissions changes are required for supporting OIDC tokens with npmjs.com.