### PR TITLE
OIDC publishing requires Node 22 or later

### DIFF
--- a/.github/workflows/base-publish-release.yml
+++ b/.github/workflows/base-publish-release.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies


### PR DESCRIPTION
Seeing if updating from Node 20 will fix the OIDC publishing failures.