### PR TITLE
Permissions may need to be set at the base publishing level

### DIFF
--- a/.github/workflows/base-publish-release.yml
+++ b/.github/workflows/base-publish-release.yml
@@ -31,6 +31,7 @@ jobs:
   publish-release:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write # Required for OIDC
       contents: write
       packages: write
 


### PR DESCRIPTION
Still trying to get OIDC working. Permissions may need to be at the base publishing level.