### PR TITLE
Provenance failed on publish, due to missing repo in sub-packages

### DIFF
--- a/packages/mcp-workflow/package.json
+++ b/packages/mcp-workflow/package.json
@@ -24,6 +24,10 @@
     "lint": "eslint --max-warnings 0 --config ../../eslint.config.mjs \"{src,tests}/**/*.ts\"",
     "format": "prettier --write \"{src,tests}/**/*.ts\""
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forcedotcom/mobile-mcp-tools.git"
+  },
   "dependencies": {
     "@langchain/langgraph": "^0.4.9",
     "@langchain/langgraph-checkpoint": "^0.0.11",

--- a/packages/mobile-native-mcp-server/package.json
+++ b/packages/mobile-native-mcp-server/package.json
@@ -30,6 +30,10 @@
     "format": "prettier --write \"{src,tests}/**/*.ts\"",
     "inspect": "npx @modelcontextprotocol/inspector node dist/index.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/forcedotcom/mobile-mcp-tools.git"
+  },
   "dependencies": {
     "@langchain/langgraph": "^0.4.9",
     "@modelcontextprotocol/sdk": "^1.26.0",


### PR DESCRIPTION
Still trying to fix OIDC issues. Next failure is:

> npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
> npm notice publish Signed provenance statement with source and build information from GitHub Actions
> npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=946248236
> npm error code E422
> npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@salesforce%2fmagen-mcp-workflow - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/forcedotcom/mobile-mcp-tools" from provenance

So I'm creating the `repository` entries in the publishable packages.